### PR TITLE
Create new regex rules to get rid of ellipsis (`...`) in the code examples

### DIFF
--- a/src/openApiFormatter.js
+++ b/src/openApiFormatter.js
@@ -54,8 +54,29 @@ const formatter = {
         return apiProperty;
     },
     mapResponseFromExample(example) {
+        if (example === null) {
+            return null;
+        }
+
         try {
-            let json = example.replaceAll('\n', '').replace(new RegExp('[}][,]?[\\s]+[\\.]{3}', 'g'), "}");
+            let json = example.replaceAll('\n', '')
+                // Get rid of `...` in the beginning of an object
+                .replace(new RegExp("[\\{][\\s]*([\\.][\\s]?){3}(?=[\\s]*[\"])", "g"), "{")
+                // Get rid of `...` in the middle of an object
+                .replace(new RegExp("[,][\\s]*([\\.][\\s]?){3}(?=[\\s]*[\"])", "g"), ",")
+                // Get rid of `...` at the end of an object
+                .replace(new RegExp("[,]?[\\s]*([\\.][\\s]?){3}(?=[\\s]*[\\}])", "g"), "")
+
+                // Get rid of `...` in the beginning of an array
+                .replace(new RegExp("[\\[][\\s]*([\\.][\\s]?){3}(?=[\\s]*[\\{])", "g"), "[")
+                // Get rid of `...` in the middle of an array
+                .replace(new RegExp("[}][,]?[\\s]*([\\.][\\s]?){3}(?=[\\s]*[\\{])", "g"), "},")
+                // Get rid of `...` at the end of an array
+                .replace(new RegExp("[}][,]?[\\s]*([\\.][\\s]?){3}(?=[\\s]*[\\]])", "g"), "}")
+
+                // Get rid of trailing comma at the end of an array
+                .replace(new RegExp("[}][,][\\s]*(?=[\\s]*[\\]])", "g"), "}");
+
             return this.mapPropertiesToOpenApi(JSON.parse(json))
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
Hi! As I said in the other repo, I took a look at the scrapper.

I added some new regex rules that will handle more cases in which the ellipsis (`...`) within the code examples could mess up the JSON parsing. Notably, these rules include:
  - Look ahead to determine whether we are in an object/array and whether the ellipsis occurs at the beginning, in the middle, or at the end.
  - Allow for whitespace within the ellipsis (this is the case for some of the doc examples.

The changes fix most of the parsing issues regarding the examples, except:
  - An actual JSON syntax issue in `GET /extensions/transactions` (I will see how I can report this to Twitch, it is just missing a couple commas)
  - Endpoints for which there are no examples (the server doesn't send a response body; this could maybe be inferred from the fact that there is no example at all and handle it like that)
  - Endpoints for which the examples show a string `204 No Content` (I figure this could also be inferred from the "Response Codes" tables in the docs)

Finally, I ran `swagger-cli validate` and the resulting spec looks fine to me, but please let me know if I missed anything 😄 

Cheers!